### PR TITLE
feat: MOVE patch를 추가해 keyed reorder 기반 마련

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -23,4 +23,5 @@ export const PatchType = Object.freeze({
   PROPS: "PROPS",
   ADD: "ADD",
   REMOVE: "REMOVE",
+  MOVE: "MOVE",
 });

--- a/src/lib/applyPatches.js
+++ b/src/lib/applyPatches.js
@@ -61,6 +61,22 @@ function normalizePatch(patch) {
         path: [...patch.path],
         props: normalizeProps(patch.props),
       };
+    case PatchType.MOVE:
+      if (
+        !Number.isInteger(patch.fromIndex) ||
+        !Number.isInteger(patch.toIndex) ||
+        patch.fromIndex < 0 ||
+        patch.toIndex < 0
+      ) {
+        throw new TypeError("Invalid patch.");
+      }
+
+      return {
+        type: PatchType.MOVE,
+        path: [...patch.path],
+        fromIndex: patch.fromIndex,
+        toIndex: patch.toIndex,
+      };
     case PatchType.REMOVE:
       return {
         type: PatchType.REMOVE,
@@ -79,27 +95,54 @@ function isValidPath(path) {
 }
 
 function orderPatches(patches) {
-  const removals = patches
-    .filter((patch) => patch.type === PatchType.REMOVE)
-    .sort(compareRemovalPaths);
+  const structural = patches
+    .filter((patch) => isStructuralPatch(patch.type))
+    .sort(compareStructuralPatches);
   const updates = patches
-    .filter(
-      (patch) => patch.type !== PatchType.REMOVE && patch.type !== PatchType.ADD,
-    )
-    .sort((left, right) => comparePaths(left.path, right.path));
-  const additions = patches
-    .filter((patch) => patch.type === PatchType.ADD)
+    .filter((patch) => !isStructuralPatch(patch.type))
     .sort((left, right) => comparePaths(left.path, right.path));
 
-  return [...removals, ...updates, ...additions];
+  return [...structural, ...updates];
 }
 
-function compareRemovalPaths(left, right) {
-  if (left.path.length !== right.path.length) {
-    return right.path.length - left.path.length;
+function isStructuralPatch(type) {
+  return (
+    type === PatchType.REMOVE ||
+    type === PatchType.ADD ||
+    type === PatchType.MOVE
+  );
+}
+
+function compareStructuralPatches(left, right) {
+  const parentComparison = comparePaths(getParentPath(left), getParentPath(right));
+
+  if (parentComparison !== 0) {
+    return parentComparison;
   }
 
-  return comparePaths(right.path, left.path);
+  if (left.type === PatchType.REMOVE && right.type === PatchType.REMOVE) {
+    const leftIndex = left.path[left.path.length - 1] ?? -1;
+    const rightIndex = right.path[right.path.length - 1] ?? -1;
+    return rightIndex - leftIndex;
+  }
+
+  if (left.type === PatchType.REMOVE) {
+    return -1;
+  }
+
+  if (right.type === PatchType.REMOVE) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function getParentPath(patch) {
+  if (patch.type === PatchType.MOVE || patch.path.length === 0) {
+    return patch.path;
+  }
+
+  return patch.path.slice(0, -1);
 }
 
 function comparePaths(leftPath, rightPath) {
@@ -124,6 +167,8 @@ function applyPatch(rootDom, patch) {
       return applyPropsPatch(rootDom, patch);
     case PatchType.ADD:
       return applyAddPatch(rootDom, patch);
+    case PatchType.MOVE:
+      return applyMovePatch(rootDom, patch);
     case PatchType.REMOVE:
       return applyRemovePatch(rootDom, patch);
     default:
@@ -194,6 +239,29 @@ function applyAddPatch(rootDom, patch) {
   }
 
   parent.insertBefore(nextDom, parent.childNodes[childIndex] ?? null);
+  return rootDom;
+}
+
+function applyMovePatch(rootDom, patch) {
+  const parent = getNodeAtPath(rootDom, patch.path);
+
+  if (!parent || patch.fromIndex === patch.toIndex) {
+    return rootDom;
+  }
+
+  const target = parent.childNodes[patch.fromIndex];
+
+  if (!target) {
+    return rootDom;
+  }
+
+  // Moving the existing DOM node preserves identity, which is why keyed reorders need MOVE.
+  const referenceIndex = patch.fromIndex < patch.toIndex
+    ? patch.toIndex + 1
+    : patch.toIndex;
+  const referenceNode = parent.childNodes[referenceIndex] ?? null;
+
+  parent.insertBefore(target, referenceNode);
   return rootDom;
 }
 

--- a/src/lib/domProps.js
+++ b/src/lib/domProps.js
@@ -1,4 +1,9 @@
 export function setDomProp(element, key, value) {
+  // `key` participates in reconciliation only, so it should never leak into the DOM.
+  if (key === "key") {
+    return;
+  }
+
   const normalizedKey = key === "class" ? "className" : key;
   const attributeName = normalizedKey === "className" ? "class" : normalizedKey;
 
@@ -31,6 +36,10 @@ export function setDomProp(element, key, value) {
 }
 
 export function removeDomProp(element, key) {
+  if (key === "key") {
+    return;
+  }
+
   const normalizedKey = key === "class" ? "className" : key;
   const attributeName = normalizedKey === "className" ? "class" : normalizedKey;
 

--- a/src/ui-helper.js
+++ b/src/ui-helper.js
@@ -148,6 +148,7 @@ export function formatSnapshotComparison(previousVdom, currentVdom, patches) {
       case PatchType.TEXT:
       case PatchType.PROPS:
       case PatchType.REPLACE:
+      case PatchType.MOVE:
         leftAffectedPaths.push({ path, type: patch.type });
         rightAffectedPaths.push({ path, type: patch.type });
         break;


### PR DESCRIPTION
## 요약
keyed child reorder에서 DOM node identity를 유지할 수 있도록 MOVE patch를 도입했습니다.

## 변경 사항
- PatchType.MOVE 추가
- applyPatches에 MOVE 검증 및 적용 로직 추가
- structural patch ordering 보강
- key를 DOM prop 처리 대상에서 제외

## 테스트
- node --check src/lib/applyPatches.js
- node --check src/lib/domProps.js
- node --check src/ui-helper.js

## 비고
후속 key 기반 child reconciliation이 이 patch 타입을 사용합니다.

Closes #1
