### PR TITLE
feat: child diff에 key 기반 reconciliation 추가

### DIFF
--- a/src/lib/diff.js
+++ b/src/lib/diff.js
@@ -108,8 +108,8 @@ function isDeepEqual(a, b) {
 
   const aProps = a.props ?? {};
   const bProps = b.props ?? {};
-  const aKeys = Object.keys(aProps);
-  const bKeys = Object.keys(bProps);
+  const aKeys = Object.keys(aProps).filter((key) => key !== "key");
+  const bKeys = Object.keys(bProps).filter((key) => key !== "key");
 
   if (aKeys.length !== bKeys.length) {
     return false;
@@ -128,8 +128,8 @@ function isDeepEqual(a, b) {
     return false;
   }
 
-  for (let i = 0; i < aChildren.length; i += 1) {
-    if (!isDeepEqual(aChildren[i], bChildren[i])) {
+  for (let index = 0; index < aChildren.length; index += 1) {
+    if (!isDeepEqual(aChildren[index], bChildren[index])) {
       return false;
     }
   }
@@ -142,19 +142,19 @@ function tryFindRemoved(oldChildren, newChildren) {
     return -1;
   }
 
-  let k = 0;
+  let pivot = 0;
 
-  while (k < newChildren.length && isDeepEqual(oldChildren[k], newChildren[k])) {
-    k += 1;
+  while (pivot < newChildren.length && isDeepEqual(oldChildren[pivot], newChildren[pivot])) {
+    pivot += 1;
   }
 
-  for (let i = k; i < newChildren.length; i += 1) {
-    if (!isDeepEqual(oldChildren[i + 1], newChildren[i])) {
+  for (let index = pivot; index < newChildren.length; index += 1) {
+    if (!isDeepEqual(oldChildren[index + 1], newChildren[index])) {
       return -1;
     }
   }
 
-  return k;
+  return pivot;
 }
 
 function tryFindAdded(oldChildren, newChildren) {
@@ -162,46 +162,181 @@ function tryFindAdded(oldChildren, newChildren) {
     return -1;
   }
 
-  let k = 0;
+  let pivot = 0;
 
-  while (k < oldChildren.length && isDeepEqual(oldChildren[k], newChildren[k])) {
-    k += 1;
+  while (pivot < oldChildren.length && isDeepEqual(oldChildren[pivot], newChildren[pivot])) {
+    pivot += 1;
   }
 
-  for (let i = k; i < oldChildren.length; i += 1) {
-    if (!isDeepEqual(oldChildren[i], newChildren[i + 1])) {
+  for (let index = pivot; index < oldChildren.length; index += 1) {
+    if (!isDeepEqual(oldChildren[index], newChildren[index + 1])) {
       return -1;
     }
   }
 
-  return k;
+  return pivot;
 }
 
 function diffChildren(oldChildren, newChildren, path, patches) {
+  assertUniqueKeys(oldChildren);
+  assertUniqueKeys(newChildren);
+
+  const oldMode = getChildListMode(oldChildren);
+  const newMode = getChildListMode(newChildren);
+
+  if (oldMode === "keyed" && newMode === "keyed") {
+    diffKeyedChildren(oldChildren, newChildren, path, patches);
+    return;
+  }
+
+  // Mixing keyed and unkeyed siblings is ambiguous, so we keep the old index-based behavior.
+  diffChildrenByIndex(oldChildren, newChildren, path, patches);
+}
+
+function diffChildrenByIndex(oldChildren, newChildren, path, patches) {
   const removedIndex = tryFindRemoved(oldChildren, newChildren);
 
   if (removedIndex !== -1) {
-    patches.push({ type: PatchType.REMOVE, path: [...path, removedIndex] });
+    patches.push({
+      type: PatchType.REMOVE,
+      path: [...path, removedIndex],
+    });
     return;
   }
 
   const addedIndex = tryFindAdded(oldChildren, newChildren);
 
   if (addedIndex !== -1) {
-    patches.push({ type: PatchType.ADD, path: [...path, addedIndex], node: newChildren[addedIndex] });
+    patches.push({
+      type: PatchType.ADD,
+      path: [...path, addedIndex],
+      node: newChildren[addedIndex],
+    });
     return;
   }
 
   const maxLength = Math.max(oldChildren.length, newChildren.length);
 
   for (let index = 0; index < maxLength; index += 1) {
-    walk(
-      oldChildren[index],
-      newChildren[index],
-      [...path, index],
-      patches,
-    );
+    walk(oldChildren[index], newChildren[index], [...path, index], patches);
   }
+}
+
+function diffKeyedChildren(oldChildren, newChildren, path, patches) {
+  const oldChildrenByKey = mapChildrenByKey(oldChildren);
+  const newChildrenByKey = mapChildrenByKey(newChildren);
+  const workingKeys = oldChildren.map((child) => getNodeKey(child));
+
+  for (let oldIndex = oldChildren.length - 1; oldIndex >= 0; oldIndex -= 1) {
+    const oldKey = getNodeKey(oldChildren[oldIndex]);
+
+    if (!newChildrenByKey.has(oldKey)) {
+      patches.push({
+        type: PatchType.REMOVE,
+        path: [...path, oldIndex],
+      });
+      workingKeys.splice(oldIndex, 1);
+    }
+  }
+
+  for (let newIndex = 0; newIndex < newChildren.length; newIndex += 1) {
+    const newKey = getNodeKey(newChildren[newIndex]);
+
+    if (workingKeys[newIndex] === newKey) {
+      continue;
+    }
+
+    const currentIndex = workingKeys.indexOf(newKey);
+
+    if (currentIndex === -1) {
+      patches.push({
+        type: PatchType.ADD,
+        path: [...path, newIndex],
+        node: newChildren[newIndex],
+      });
+      workingKeys.splice(newIndex, 0, newKey);
+      continue;
+    }
+
+    patches.push({
+      type: PatchType.MOVE,
+      path,
+      fromIndex: currentIndex,
+      toIndex: newIndex,
+    });
+    moveItem(workingKeys, currentIndex, newIndex);
+  }
+
+  for (let newIndex = 0; newIndex < newChildren.length; newIndex += 1) {
+    const newChild = newChildren[newIndex];
+    const oldChild = oldChildrenByKey.get(getNodeKey(newChild));
+
+    if (!oldChild) {
+      continue;
+    }
+
+    walk(oldChild, newChild, [...path, newIndex], patches);
+  }
+}
+
+function assertUniqueKeys(children) {
+  const seenKeys = new Map();
+
+  for (const child of children) {
+    const key = getNodeKey(child);
+
+    if (key === undefined) {
+      continue;
+    }
+
+    if (seenKeys.has(key)) {
+      throw new Error(`Duplicate key "${String(key)}" among siblings.`);
+    }
+
+    seenKeys.set(key, true);
+  }
+}
+
+function getChildListMode(children) {
+  if (children.length === 0) {
+    return "unkeyed";
+  }
+
+  const keyedChildrenCount = children.filter((child) => getNodeKey(child) !== undefined).length;
+
+  if (keyedChildrenCount === 0) {
+    return "unkeyed";
+  }
+
+  if (keyedChildrenCount === children.length) {
+    return "keyed";
+  }
+
+  return "mixed";
+}
+
+function mapChildrenByKey(children) {
+  const childrenByKey = new Map();
+
+  for (const child of children) {
+    childrenByKey.set(getNodeKey(child), child);
+  }
+
+  return childrenByKey;
+}
+
+function getNodeKey(node) {
+  if (node?.nodeType !== NodeType.ELEMENT) {
+    return undefined;
+  }
+
+  const key = node.props?.key;
+  return key === undefined || key === null ? undefined : key;
+}
+
+function moveItem(list, fromIndex, toIndex) {
+  const [item] = list.splice(fromIndex, 1);
+  list.splice(toIndex, 0, item);
 }
 
 function diffProps(oldProps = {}, newProps = {}) {
@@ -209,7 +344,7 @@ function diffProps(oldProps = {}, newProps = {}) {
   const keys = new Set([...Object.keys(oldProps), ...Object.keys(newProps)]);
 
   for (const key of keys) {
-    if (oldProps[key] === newProps[key]) {
+    if (key === "key" || oldProps[key] === newProps[key]) {
       continue;
     }
 

--- a/tests/lib/applyPatches.test.js
+++ b/tests/lib/applyPatches.test.js
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import { applyPatches } from "../../src/lib/applyPatches.js";
 import { diff } from "../../src/lib/diff.js";
-import { elementNode, textNode } from "../../src/constants.js";
+import { PatchType, elementNode, textNode } from "../../src/constants.js";
 
 describe("applyPatches", () => {
   it("applyPatches 함수가 export된다", () => {
@@ -82,6 +82,45 @@ describe("applyPatches", () => {
     expect(patchedRoot.textContent).toBe("after");
   });
 
+  it("MOVE 패치로 keyed reorder 시 기존 DOM node identity를 유지한다", () => {
+    const rootDom = document.createElement("ul");
+    const first = document.createElement("li");
+    const second = document.createElement("li");
+    const third = document.createElement("li");
+
+    first.textContent = "A";
+    second.textContent = "B";
+    third.textContent = "C";
+    rootDom.append(first, second, third);
+
+    const oldVdom = elementNode("ul", {}, [
+      elementNode("li", { key: "a" }, [textNode("A")]),
+      elementNode("li", { key: "b" }, [textNode("B")]),
+      elementNode("li", { key: "c" }, [textNode("C")]),
+    ]);
+    const newVdom = elementNode("ul", {}, [
+      elementNode("li", { key: "c" }, [textNode("C")]),
+      elementNode("li", { key: "a" }, [textNode("A")]),
+      elementNode("li", { key: "b" }, [textNode("B")]),
+    ]);
+
+    const patches = diff(oldVdom, newVdom);
+    const patchedRoot = applyPatches(rootDom, patches);
+
+    expect(patches).toEqual([
+      {
+        type: PatchType.MOVE,
+        path: [],
+        fromIndex: 2,
+        toIndex: 0,
+      },
+    ]);
+    expect(patchedRoot.childNodes[0]).toBe(third);
+    expect(patchedRoot.childNodes[1]).toBe(first);
+    expect(patchedRoot.childNodes[2]).toBe(second);
+    expect(patchedRoot.outerHTML).toBe("<ul><li>C</li><li>A</li><li>B</li></ul>");
+  });
+
   it("잘못된 patch 입력이면 일관된 TypeError를 던진다", () => {
     const rootDom = document.createElement("div");
 
@@ -93,6 +132,9 @@ describe("applyPatches", () => {
     ).toThrowError(new TypeError("Invalid patch."));
     expect(() =>
       applyPatches(rootDom, [{ type: "TEXT", path: ["nope"], value: "x" }]),
+    ).toThrowError(new TypeError("Invalid patch."));
+    expect(() =>
+      applyPatches(rootDom, [{ type: PatchType.MOVE, path: [], fromIndex: -1, toIndex: 0 }]),
     ).toThrowError(new TypeError("Invalid patch."));
   });
 });

--- a/tests/lib/diff.test.js
+++ b/tests/lib/diff.test.js
@@ -96,6 +96,68 @@ describe("diff", () => {
     ]);
   });
 
+  it("fully keyed sibling list는 reorder를 MOVE 패치로 만든다", () => {
+    const oldVdom = elementNode("ul", {}, [
+      elementNode("li", { key: "a" }, [textNode("A")]),
+      elementNode("li", { key: "b" }, [textNode("B")]),
+      elementNode("li", { key: "c" }, [textNode("C")]),
+    ]);
+    const newVdom = elementNode("ul", {}, [
+      elementNode("li", { key: "c" }, [textNode("C")]),
+      elementNode("li", { key: "a" }, [textNode("A")]),
+      elementNode("li", { key: "b" }, [textNode("B")]),
+    ]);
+
+    const actual = diff(oldVdom, newVdom);
+
+    expect(actual).toEqual([
+      {
+        type: PatchType.MOVE,
+        path: [],
+        fromIndex: 2,
+        toIndex: 0,
+      },
+    ]);
+  });
+
+  it("keyed sibling list에서 key가 중복되면 명확한 에러를 던진다", () => {
+    const oldVdom = elementNode("ul", {}, [
+      elementNode("li", { key: "dup" }, [textNode("A")]),
+      elementNode("li", { key: "dup" }, [textNode("B")]),
+    ]);
+    const newVdom = elementNode("ul", {}, []);
+
+    expect(() => diff(oldVdom, newVdom)).toThrowError(
+      new Error('Duplicate key "dup" among siblings.'),
+    );
+  });
+
+  it("keyed/unkeyed가 섞인 sibling list는 기존 index 기반 비교로 fallback한다", () => {
+    const oldVdom = elementNode("ul", {}, [
+      elementNode("li", { key: "a" }, [textNode("A")]),
+      elementNode("li", {}, [textNode("B")]),
+    ]);
+    const newVdom = elementNode("ul", {}, [
+      elementNode("li", {}, [textNode("B")]),
+      elementNode("li", { key: "a" }, [textNode("A")]),
+    ]);
+
+    const actual = diff(oldVdom, newVdom);
+
+    expect(actual).toEqual([
+      {
+        type: PatchType.TEXT,
+        path: [0, 0],
+        value: "B",
+      },
+      {
+        type: PatchType.TEXT,
+        path: [1, 0],
+        value: "A",
+      },
+    ]);
+  });
+
   it("잘못된 vnode 입력이면 일관된 TypeError를 던진다", () => {
     expect(() => diff({}, {})).toThrowError(new TypeError("Invalid vnode."));
     expect(() => diff(null, {})).toThrowError(new TypeError("Invalid vnode."));

--- a/tests/lib/edgeCases.test.js
+++ b/tests/lib/edgeCases.test.js
@@ -158,13 +158,8 @@ describe("엣지 케이스", () => {
       // then
       expect(patches).toEqual([
         {
-          type: PatchType.REPLACE,
-          path: [0],
-          node: elementNode("p", {}, [textNode("C")]),
-        },
-        {
           type: PatchType.REMOVE,
-          path: [1],
+          path: [0],
         },
       ]);
       expect(
@@ -237,7 +232,7 @@ describe("엣지 케이스", () => {
       expect(removeDom.mount.innerHTML).toBe("<br>");
     });
 
-    it("앞쪽 삽입 시 뒤 형제 identity를 재사용하지 않는다", () => {
+    it("앞쪽 삽입 시 뒤 형제 DOM identity를 유지한다", () => {
       // given
       const { root } = makeDom(`
         <div id="root">
@@ -262,36 +257,16 @@ describe("엣지 케이스", () => {
       // then
       expect(patches).toEqual([
         {
-          type: PatchType.PROPS,
-          path: [0],
-          props: { id: "a" },
-        },
-        {
-          type: PatchType.TEXT,
-          path: [0, 0],
-          value: "A",
-        },
-        {
-          type: PatchType.PROPS,
-          path: [1],
-          props: { id: "b" },
-        },
-        {
-          type: PatchType.TEXT,
-          path: [1, 0],
-          value: "B",
-        },
-        {
           type: PatchType.ADD,
-          path: [2],
-          node: elementNode("span", { id: "c" }, [textNode("C")]),
+          path: [0],
+          node: elementNode("span", { id: "a" }, [textNode("A")]),
         },
       ]);
       expect(root.outerHTML).toBe(
         '<div id="root"><span id="a">A</span><span id="b">B</span><span id="c">C</span></div>',
       );
-      expect(root.childNodes[1]).not.toBe(before[0]);
-      expect(root.childNodes[2]).not.toBe(before[1]);
+      expect(root.childNodes[1]).toBe(before[0]);
+      expect(root.childNodes[2]).toBe(before[1]);
     });
 
     it("형제 reorder를 인덱스 기반 텍스트 업데이트로 처리한다", () => {
@@ -331,6 +306,45 @@ describe("엣지 케이스", () => {
       expect(root.outerHTML).toBe("<ul><li>B</li><li>A</li></ul>");
       expect(root.childNodes[0]).toBe(before[0]);
       expect(root.childNodes[1]).toBe(before[1]);
+    });
+
+    it("fully keyed sibling reorder는 MOVE로 기존 DOM identity를 유지한다", () => {
+      // given
+      const { root } = makeDom(`
+        <ul>
+          <li>A</li>
+          <li>B</li>
+          <li>C</li>
+        </ul>
+      `);
+      const before = captureChildren(root);
+      const oldVdom = elementNode("ul", {}, [
+        elementNode("li", { key: "a" }, [textNode("A")]),
+        elementNode("li", { key: "b" }, [textNode("B")]),
+        elementNode("li", { key: "c" }, [textNode("C")]),
+      ]);
+      const newVdom = elementNode("ul", {}, [
+        elementNode("li", { key: "c" }, [textNode("C")]),
+        elementNode("li", { key: "a" }, [textNode("A")]),
+        elementNode("li", { key: "b" }, [textNode("B")]),
+      ]);
+
+      // when
+      const { patches } = patchFrom(oldVdom, newVdom, root);
+
+      // then
+      expect(patches).toEqual([
+        {
+          type: PatchType.MOVE,
+          path: [],
+          fromIndex: 2,
+          toIndex: 0,
+        },
+      ]);
+      expect(root.outerHTML).toBe("<ul><li>C</li><li>A</li><li>B</li></ul>");
+      expect(root.childNodes[0]).toBe(before[2]);
+      expect(root.childNodes[1]).toBe(before[0]);
+      expect(root.childNodes[2]).toBe(before[1]);
     });
   });
 

--- a/tests/lib/vdomToDom.test.js
+++ b/tests/lib/vdomToDom.test.js
@@ -67,6 +67,20 @@ describe("vdomToDom", () => {
     expect(domNode.childNodes).toHaveLength(2);
   });
 
+  it("reconciliation용 key prop은 실제 DOM attribute로 렌더링하지 않는다", () => {
+    const vnode = elementNode("button", {
+      key: "save-button",
+      id: "save",
+    }, [
+      textNode("Save"),
+    ]);
+
+    const domNode = vdomToDom(vnode);
+
+    expect(domNode.getAttribute("id")).toBe("save");
+    expect(domNode.hasAttribute("key")).toBe(false);
+  });
+
   it("잘못된 vnode 입력이면 일관된 TypeError를 던진다", () => {
     expect(() => vdomToDom({})).toThrowError(new TypeError("Invalid vnode."));
   });


### PR DESCRIPTION
## 요약
child diff를 fully keyed sibling list에서 key 기반으로 reconcile하도록 확장했습니다.

## 변경 사항
- fully keyed sibling list에 key 기반 reconciliation 추가
- mixed keyed/unkeyed list fallback 유지
- duplicate key 에러 처리 추가
- keyed diff 및 edge case 테스트 보강

## 테스트
- node --check src/lib/diff.js
- node --check tests/lib/diff.test.js
- node --check tests/lib/edgeCases.test.js
- node --check tests/lib/vdomToDom.test.js

## 비고
이 PR은 feat-#1 위에 쌓이는 stacked PR입니다.

Closes #3
