### PR TITLE
feat: root 전용 hooks runtime 추가

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -4,3 +4,10 @@ export { vdomToDom } from "./lib/vdomToDom.js";
 export { renderTo } from "./lib/renderTo.js";
 export { diff } from "./lib/diff.js";
 export { applyPatches } from "./lib/applyPatches.js";
+export {
+  FunctionComponent,
+  mountRoot,
+  useEffect,
+  useMemo,
+  useState,
+} from "./rootRuntime.js";

--- a/src/rootRuntime.js
+++ b/src/rootRuntime.js
@@ -1,0 +1,292 @@
+import { applyPatches } from "./lib/applyPatches.js";
+import { diff } from "./lib/diff.js";
+import { renderTo } from "./lib/renderTo.js";
+
+let activeRuntime = null;
+
+export class FunctionComponent {
+  constructor(renderFn) {
+    if (typeof renderFn !== "function") {
+      throw new TypeError("FunctionComponent requires a render function.");
+    }
+
+    this.renderFn = renderFn;
+  }
+
+  render(props) {
+    return this.renderFn(props);
+  }
+}
+
+export function mountRoot(container, rootComponent, initialProps = {}) {
+  if (!container || typeof container.replaceChildren !== "function") {
+    throw new TypeError("mountRoot requires a valid container.");
+  }
+
+  if (!(rootComponent instanceof FunctionComponent)) {
+    throw new TypeError("mountRoot requires a FunctionComponent root.");
+  }
+
+  const runtime = {
+    container,
+    rootComponent,
+    rootProps: initialProps,
+    currentVdom: null,
+    rootDom: null,
+    hookSlots: [],
+    hookIndex: 0,
+    pendingEffects: [],
+    hookCount: null,
+    isRendering: false,
+    isFlushingEffects: false,
+    needsRerender: false,
+    isUnmounted: false,
+  };
+
+  rerenderRuntime(runtime);
+
+  return {
+    rerender() {
+      rerenderRuntime(runtime);
+    },
+    setProps(nextProps = {}) {
+      runtime.rootProps = nextProps;
+      rerenderRuntime(runtime);
+    },
+    unmount() {
+      if (runtime.isUnmounted) {
+        return;
+      }
+
+      cleanupEffectSlots(runtime);
+
+      if (runtime.currentVdom != null && runtime.rootDom != null) {
+        runtime.rootDom = applyPatches(runtime.rootDom, diff(runtime.currentVdom, null));
+      }
+
+      container.replaceChildren();
+      runtime.currentVdom = null;
+      runtime.rootDom = null;
+      runtime.hookSlots = [];
+      runtime.hookCount = null;
+      runtime.pendingEffects = [];
+      runtime.isUnmounted = true;
+    },
+  };
+}
+
+export function useState(initialValue) {
+  const runtime = getActiveRuntime("useState");
+  const slotIndex = runtime.hookIndex;
+  let slot = runtime.hookSlots[slotIndex];
+
+  if (!slot) {
+    const value = typeof initialValue === "function" ? initialValue() : initialValue;
+
+    slot = {
+      kind: "state",
+      value,
+      // Hook state persists here, outside the function body, so the next render can reuse it.
+      setState(nextValue) {
+        const previousValue = slot.value;
+        const resolvedValue = typeof nextValue === "function"
+          ? nextValue(previousValue)
+          : nextValue;
+
+        if (Object.is(previousValue, resolvedValue)) {
+          return previousValue;
+        }
+
+        slot.value = resolvedValue;
+
+        // setState updates the stored slot value first, then reruns the root through diff + patch.
+        rerenderRuntime(runtime);
+        return resolvedValue;
+      },
+    };
+    runtime.hookSlots[slotIndex] = slot;
+  } else {
+    assertHookKind(slot, "state");
+  }
+
+  runtime.hookIndex += 1;
+  return [slot.value, slot.setState];
+}
+
+export function useMemo(factory, deps) {
+  const runtime = getActiveRuntime("useMemo");
+  const slotIndex = runtime.hookIndex;
+  let slot = runtime.hookSlots[slotIndex];
+
+  if (!slot) {
+    slot = {
+      kind: "memo",
+      value: factory(),
+      deps: cloneDeps(deps),
+    };
+    runtime.hookSlots[slotIndex] = slot;
+  } else {
+    assertHookKind(slot, "memo");
+
+    if (deps === undefined || !areHookDepsEqual(slot.deps, deps)) {
+      slot.value = factory();
+      slot.deps = cloneDeps(deps);
+    }
+  }
+
+  runtime.hookIndex += 1;
+  return slot.value;
+}
+
+export function useEffect(effect, deps) {
+  const runtime = getActiveRuntime("useEffect");
+  const slotIndex = runtime.hookIndex;
+  let slot = runtime.hookSlots[slotIndex];
+
+  if (!slot) {
+    slot = {
+      kind: "effect",
+      deps: undefined,
+      cleanup: undefined,
+    };
+    runtime.hookSlots[slotIndex] = slot;
+  } else {
+    assertHookKind(slot, "effect");
+  }
+
+  if (deps === undefined || !areHookDepsEqual(slot.deps, deps)) {
+    runtime.pendingEffects.push({
+      slotIndex,
+      effect,
+      deps,
+    });
+  }
+
+  runtime.hookIndex += 1;
+}
+
+function rerenderRuntime(runtime) {
+  if (runtime.isUnmounted) {
+    return;
+  }
+
+  if (runtime.isRendering || runtime.isFlushingEffects) {
+    runtime.needsRerender = true;
+    return;
+  }
+
+  do {
+    runtime.needsRerender = false;
+
+    const nextVdom = renderRoot(runtime);
+
+    if (runtime.currentVdom == null) {
+      renderTo(runtime.container, nextVdom);
+      runtime.rootDom = runtime.container.firstChild ?? null;
+    } else {
+      runtime.rootDom = applyPatches(runtime.rootDom, diff(runtime.currentVdom, nextVdom));
+    }
+
+    runtime.currentVdom = nextVdom;
+    flushEffects(runtime);
+  } while (runtime.needsRerender);
+}
+
+function renderRoot(runtime) {
+  runtime.pendingEffects = [];
+  // hookIndex resets every render so the root function reads its hook slots in the same order.
+  runtime.hookIndex = 0;
+  runtime.isRendering = true;
+  activeRuntime = runtime;
+
+  try {
+    const nextVdom = runtime.rootComponent.render(runtime.rootProps);
+
+    if (nextVdom == null) {
+      throw new TypeError("Root component must return a vnode.");
+    }
+
+    if (runtime.hookCount !== null && runtime.hookCount !== runtime.hookIndex) {
+      throw new Error("Hook order changed between renders.");
+    }
+
+    runtime.hookCount = runtime.hookIndex;
+    return nextVdom;
+  } finally {
+    activeRuntime = null;
+    runtime.isRendering = false;
+  }
+}
+
+function flushEffects(runtime) {
+  const effects = runtime.pendingEffects;
+  runtime.pendingEffects = [];
+
+  if (effects.length === 0) {
+    return;
+  }
+
+  runtime.isFlushingEffects = true;
+
+  try {
+    for (const { slotIndex, effect, deps } of effects) {
+      const slot = runtime.hookSlots[slotIndex];
+
+      if (typeof slot.cleanup === "function") {
+        slot.cleanup();
+      }
+
+      const cleanup = effect();
+
+      slot.cleanup = typeof cleanup === "function" ? cleanup : undefined;
+      slot.deps = cloneDeps(deps);
+    }
+  } finally {
+    runtime.isFlushingEffects = false;
+  }
+}
+
+function cleanupEffectSlots(runtime) {
+  for (const slot of runtime.hookSlots) {
+    if (slot?.kind === "effect" && typeof slot.cleanup === "function") {
+      slot.cleanup();
+      slot.cleanup = undefined;
+    }
+  }
+}
+
+function getActiveRuntime(hookName) {
+  if (!activeRuntime || activeRuntime.isUnmounted) {
+    throw new Error(`${hookName} must be called during an active root render.`);
+  }
+
+  return activeRuntime;
+}
+
+function assertHookKind(slot, expectedKind) {
+  if (slot.kind !== expectedKind) {
+    throw new Error("Hook order changed between renders.");
+  }
+}
+
+function areHookDepsEqual(previousDeps, nextDeps) {
+  if (!Array.isArray(previousDeps) || !Array.isArray(nextDeps)) {
+    return false;
+  }
+
+  if (previousDeps.length !== nextDeps.length) {
+    return false;
+  }
+
+  for (let index = 0; index < previousDeps.length; index += 1) {
+    if (!Object.is(previousDeps[index], nextDeps[index])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function cloneDeps(deps) {
+  return Array.isArray(deps) ? [...deps] : undefined;
+}

--- a/tests/rootRuntime.test.js
+++ b/tests/rootRuntime.test.js
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { FunctionComponent, mountRoot, useEffect, useMemo, useState } from "../src/rootRuntime.js";
+import { elementNode, textNode } from "../src/constants.js";
+
+function CounterLabel(props) {
+  return elementNode("p", { "data-kind": "child" }, [
+    textNode(`${props.label}: ${props.value}`),
+  ]);
+}
+
+describe("root runtime", () => {
+  it("initial mount renders the root FunctionComponent and plain child function together", () => {
+    const container = document.createElement("div");
+    const Root = new FunctionComponent((props) => {
+      const [count] = useState(props.initialCount);
+
+      return elementNode("section", { id: "app" }, [
+        CounterLabel({ label: "Count", value: String(count) }),
+      ]);
+    });
+
+    mountRoot(container, Root, { initialCount: 1 });
+
+    expect(container.innerHTML).toBe(
+      '<section id="app"><p data-kind="child">Count: 1</p></section>',
+    );
+  });
+
+  it("useState setter가 root를 다시 렌더링하고 Object.is가 같으면 skip한다", () => {
+    const container = document.createElement("div");
+    let setCount;
+    let renderCount = 0;
+
+    const Root = new FunctionComponent(() => {
+      const [count, setState] = useState(0);
+      setCount = setState;
+      renderCount += 1;
+
+      return elementNode("section", {}, [
+        CounterLabel({ label: "Count", value: String(count) }),
+      ]);
+    });
+
+    mountRoot(container, Root);
+    setCount(1);
+    setCount(1);
+
+    expect(renderCount).toBe(2);
+    expect(container.textContent).toBe("Count: 1");
+  });
+
+  it("useMemo는 deps가 바뀔 때만 값을 다시 계산한다", () => {
+    const container = document.createElement("div");
+    let setCount;
+    let computeCount = 0;
+
+    const Root = new FunctionComponent(() => {
+      const [count, setState] = useState(1);
+      setCount = setState;
+
+      const doubled = useMemo(() => {
+        computeCount += 1;
+        return count * 2;
+      }, [count]);
+
+      return elementNode("section", {}, [
+        textNode(`count=${count}, doubled=${doubled}`),
+      ]);
+    });
+
+    mountRoot(container, Root);
+    setCount(1);
+    setCount(2);
+
+    expect(computeCount).toBe(2);
+    expect(container.textContent).toBe("count=2, doubled=4");
+  });
+
+  it("useEffect는 commit 뒤에 실행되고 deps 변경 시 cleanup 후 새 effect를 실행한다", () => {
+    const container = document.createElement("div");
+    const logs = [];
+    let setCount;
+
+    const Root = new FunctionComponent(() => {
+      const [count, setState] = useState(0);
+      setCount = setState;
+
+      useEffect(() => {
+        logs.push(`effect:${count}:${container.textContent}`);
+
+        return () => {
+          logs.push(`cleanup:${count}`);
+        };
+      }, [count]);
+
+      return elementNode("section", {}, [
+        textNode(`count:${count}`),
+      ]);
+    });
+
+    const runtime = mountRoot(container, Root);
+    setCount(1);
+    runtime.unmount();
+
+    expect(logs).toEqual([
+      "effect:0:count:0",
+      "cleanup:0",
+      "effect:1:count:1",
+      "cleanup:1",
+    ]);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("hooks are only valid during an active root render", () => {
+    expect(() => useState(0)).toThrowError(
+      new Error("useState must be called during an active root render."),
+    );
+  });
+
+  it("hook order가 바뀌면 에러를 던진다", () => {
+    const container = document.createElement("div");
+    const Root = new FunctionComponent((props) => {
+      const [count] = useState(0);
+
+      if (props.includeMemo) {
+        useMemo(() => count * 2, [count]);
+      }
+
+      return elementNode("section", {}, [textNode(String(count))]);
+    });
+
+    const runtime = mountRoot(container, Root, { includeMemo: true });
+
+    expect(() => runtime.setProps({ includeMemo: false })).toThrowError(
+      new Error("Hook order changed between renders."),
+    );
+  });
+});


### PR DESCRIPTION
## 요약
기존 렌더링 엔진 위에 root 전용 React-like hooks runtime을 추가했습니다.

## 변경 사항
- FunctionComponent, mountRoot 추가
- useState, useEffect, useMemo 추가
- root hookSlots / hookIndex 기반 rerender 흐름 추가
- runtime export 및 테스트 추가

## 테스트
- node --check src/rootRuntime.js
- node --check src/lib.js
- node --check tests/rootRuntime.test.js

## 비고
이 PR은 feat-#3 위에 쌓이는 stacked PR입니다.

Closes #5
